### PR TITLE
Add repository info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "keywords": ["purescript", "psc"],
   "author": "Nathan Faubion <nathan@n-son.com> (https://github.com/natefaubion/)",
   "license": "MIT",
+  "repository": "natefaubion/purescript-psa",
   "bin": {
     "psa": "index.js"
   },


### PR DESCRIPTION
I found out about `purescript-psa` through a tweet linking to the [npm page](https://www.npmjs.com/package/purescript-psa). With that piece of metadata, there'll be a backlink to the repo (after the next release). :octopus:

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/natefaubion/purescript-psa/7)
<!-- Reviewable:end -->
