### PR TITLE
Don't include cwd when checking library paths (fix for PS 0.12 output)

### DIFF
--- a/src/Main.purs
+++ b/src/Main.purs
@@ -174,7 +174,7 @@ main = void do
   , jsonErrors
   } <- parseOptions (defaultOptions { cwd = cwd }) argv
 
-  let opts' = opts { libDirs = (_ <> Path.sep) <<< Path.resolve [cwd] <$> opts.libDirs }
+  let opts' = opts { libDirs = Str.drop (Str.length cwd + Str.length Path.sep) <<< (_ <> Path.sep) <<< Path.resolve [cwd] <$> opts.libDirs }
       args  = Array.cons "compile" $ Array.cons "--json-errors" extra
 
   stashData <-


### PR DESCRIPTION
This is a fix for `--censor-lib` when using PureScript 0.12: it seems a change occurred between 0.11 and 0.12 where now the paths it uses are always relative.

Another fix here would have been to drop any modification of `libDirs` at all, but I figure at least by jumping through the hoops this way, if someone provides a path like `./my/libs/` or whatever it will still work out, rather than it strictly requiring arguments of the form `my/libs/` instead.