### PR TITLE
bumped dependency versions to resolve issue in typelevel-prelude

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,14 +13,14 @@
     "purescript-console": "^4.0.0",
     "purescript-node-fs": "^5.0.0",
     "purescript-node-buffer": "^5.0.0",
-    "purescript-node-child-process": "^5.0.0",
-    "purescript-node-process": "^6.0.0",
+    "purescript-node-child-process": "^6.0.0",
+    "purescript-node-process": "^7.0.0",
     "purescript-node-streams": "^4.0.0",
     "purescript-st": "^4.0.0",
-    "purescript-foreign-object": "^1.0.0",
+    "purescript-foreign-object": "^2.0.0",
     "purescript-now": "^4.0.0",
     "purescript-datetime": "^4.0.0",
-    "purescript-psa-utils": "^5.1.0",
+    "purescript-psa-utils": "^6.0.0",
     "purescript-refs": "^4.1.0",
     "purescript-ordered-collections": "^1.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "purescript-psa",
   "version": "0.7.3",
   "description": "Error/Warning reporting frontend for psc",
-  "keywords": ["purescript", "psc"],
+  "keywords": [
+    "purescript",
+    "psc"
+  ],
   "author": "Nathan Faubion <nathan@n-son.com> (https://github.com/natefaubion/)",
   "license": "MIT",
   "repository": "natefaubion/purescript-psa",


### PR DESCRIPTION
this resolves an issue where psa could not be built in some cases due to https://github.com/purescript/purescript-typelevel-prelude/issues/43.

