### PR TITLE
Can we add .spago to libDirs?

### DIFF
--- a/src/Main.purs
+++ b/src/Main.purs
@@ -138,7 +138,7 @@ parseOptions opts args =
 
   defaultLibDir x
     | Array.length x.opts.libDirs == 0 =
-      x { opts = x.opts { libDirs = [ "bower_components" ] } }
+      x { opts = x.opts { libDirs = [ "bower_components", ".spago" ] } }
     | otherwise = x
 
 main :: Effect Unit


### PR DESCRIPTION
This would make `spago build --purs-args '--censor-lib'` work out of the box. Currently, warnings which result from building dependencies through spago are not censored with `--censor-lib` unless `--is-lib=.spago` is also provided.