### PR TITLE
0.14 compatibility

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,7 @@
     "purescript-datetime": "^4.0.0",
     "purescript-psa-utils": "^6.0.0",
     "purescript-refs": "^4.1.0",
-    "purescript-ordered-collections": "^1.0.0"
+    "purescript-ordered-collections": "^1.0.0",
+    "purescript-versions": "^5.0.1"
   }
 }


### PR DESCRIPTION
Read from either stdout or stderr as appropriate based on the version
of `purs` in use. See https://github.com/purescript/purescript/issues/3672

I've tested this with both v0.13.8 and v0.14.0-rc2 using the `compile-self` npm script and it seems to work, but I haven't yet worked out what I should do with the tests in the `test` directory.