### PR TITLE
Add support for finer grained censoring of user defined warnings

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "purescript-foreign-object": "^2.0.0",
     "purescript-now": "^4.0.0",
     "purescript-datetime": "^4.0.0",
-    "purescript-psa-utils": "^6.0.0",
+    "purescript-psa-utils": "kl0tl/purescript-psa-utils#censor-user-defined-warnings",
     "purescript-refs": "^4.1.0",
     "purescript-ordered-collections": "^1.0.0",
     "purescript-versions": "^5.0.1"


### PR DESCRIPTION
This pull request adds a `--censor-user-defined-warnings=WARNING` flag to ignore Warn constraints whose message contains `WARNING`. It can be specified multiple times to ignore different warnings.

For instance, given this spago.dhall:

```dhall
{ name = "censor-user-defined-warnings"
, dependencies = [ "effect", "prelude" ]
, packages = https://raw.githubusercontent.com/purescript/package-sets/prepare-0.14/src/packages.dhall
, sources = [ "src/**/*.purs" ]
}

```

the following program:

```purescript
-- src/Example.purs
module Example where

import Prelude

import Effect (Effect)
import Prim.TypeError (class Warn, Text)

foo :: Warn (Text "'foo' is deprecated") => Unit
foo = unit

bar :: Warn (Text "'bar' is deprecated") => Unit
bar = unit

main :: Effect Unit
main = pure foo *> pure bar
```

yields those warnings when compiled with `npx spago build`:

```
[1/2 UserDefinedWarning] src/Example.purs:14:1

  14  main :: Effect Unit
      ^^^^^^^^^^^^^^^^^^^
  
  A custom warning occurred while solving type class constraints:
  
    'foo' is deprecated
  
  in value declaration main

[2/2 UserDefinedWarning] src/Example.purs:14:1

  14  main :: Effect Unit
      ^^^^^^^^^^^^^^^^^^^
  
  A custom warning occurred while solving type class constraints:
  
    'bar' is deprecated
  
  in value declaration main
```

Compiling with `npx spago build -u "--censor-user-defined-warnings=\"'foo' is deprecated\""` yields:

```
[1/1 UserDefinedWarning] src/Example.purs:14:1

  14  main :: Effect Unit
      ^^^^^^^^^^^^^^^^^^^
  
  A custom warning occurred while solving type class constraints:
  
    'bar' is deprecated
  
  in value declaration main
```

Compiling with `npx spago build -u "--strict --censor-user-defined-warnings=\"'foo' is deprecated\" --censor-user-defined-warnings=\"bar\""` yields no warnings.

This doesn’t alter the behaviour of the existing `--censor-warnings` and `--censor-codes=UserDefinedWarning` flags: `psa --censor-warnings --censor-user-defined-warnings=WARNING` still censor all warnings and `psa --censor-codes=UserDefinedWarning --censor-user-defined-warnings=WARNING` still censor all user defined warnings.

`purescript-psa-utils` has been updated with the latest Argonaut libraries, which introduces typed errors, on master so I also had to make three small unrelated changes.