### PR TITLE
Fix `--purs` option

### DIFF
--- a/src/Main.purs
+++ b/src/Main.purs
@@ -165,7 +165,7 @@ main = void do
       then readStashFile stashFile
       else emptyStash
 
-  readPursVersion \pursVer -> do
+  readPursVersion purs \pursVer -> do
     spawn' purs args \pursResult -> do
       let errorOutput =
             -- As of 0.14.0, JSON errors/warnings are written to stdout, but
@@ -219,9 +219,9 @@ main = void do
     Stream.onDataString stream Encoding.UTF8 \chunk ->
       Ref.modify_ (_ <> chunk) buffer
 
-  readPursVersion :: (Version.Version -> Effect Unit) -> Effect Unit
-  readPursVersion cb = do
-    spawn' "purs" ["--version"] \{ stdout } -> do
+  readPursVersion :: String -> (Version.Version -> Effect Unit) -> Effect Unit
+  readPursVersion purs cb = do
+    spawn' purs ["--version"] \{ stdout } -> do
       let verStr = Str.takeWhile (_ /= Str.codePointFromChar ' ') $ Str.trim stdout
       case Version.parseVersion verStr of
         Right v ->


### PR DESCRIPTION
Re: #46 

I wasn't entirely sure how to test this, but this was what I ended up doing:

Before this change:

```Console
bash-3.2$ $(pwd)/purs --version
0.13.8
bash-3.2$ node index.js --purs=$(pwd)/purs
/Users/joneshf/programming/natefaubion/purescript-psa/output/Effect.Exception/foreign.js:29
    throw e;
    ^

Error: `purs` executable not found.
    at Object.exports.error (/Users/joneshf/programming/natefaubion/purescript-psa/output/Effect.Exception/foreign.js:8:10)
    at Object.$$throw [as throw] (/Users/joneshf/programming/natefaubion/purescript-psa/output/Effect.Exception/index.js:19:45)
    at /Users/joneshf/programming/natefaubion/purescript-psa/output/Main/index.js:563:57
    at ChildProcess.<anonymous> (/Users/joneshf/programming/natefaubion/purescript-psa/output/Node.ChildProcess/foreign.js:125:17)
    at ChildProcess.emit (events.js:315:20)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:275:12)
    at onErrorNT (internal/child_process.js:465:16)
    at processTicksAndRejections (internal/process/task_queues.js:80:21)
```

After this change:

```Console
bash-3.2$ $(pwd)/purs --version
0.13.8
bash-3.2$ node index.js --purs=$(pwd)/purs
           Src   Lib   All
Warnings   0     0     0  
Errors     0     0     0  
```

Lemme know if there's something you'd like done differently.